### PR TITLE
docs: Added info for job-executor, improve installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ MANIFEST
 vendor/*
 .DS_Store
 
+.idea
+
 # Build charts
 helm-service
 helm-service*.tgz

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Helm Service
 
+**Before you start**
+
+Please consider using [job-executor-service](https://github.com/keptn-contrib/job-executor-service) and get full control
+of your deployment commands. You can find more details [here](https://artifacthub.io/packages/keptn/keptn-integrations/helm).
+
+---
+
 The *helm-service* allows deploying services to a Kubernetes cluster and releasing them to user traffic.
 Therefore, these services have to be packed as [Helm charts](https://helm.sh/docs/topics/charts/).
 For details about the Helm chart and how to onboard a service, please checkout the [docs](https://keptn.sh/docs/0.15.x/manage/service/#onboard-a-service).
@@ -12,9 +19,11 @@ either promotes or rolls back the new version depending on the (evaluation) resu
 
 ## Compatibility Matrix
 
-|      Keptn Version    | [Helm-service Docker Image](https://github.com/keptn-contrib/helm-service/pkgs/container/helm-service) |
-|:---------------------:|:------------------------------------------------------------------------------------------------------:|
-|    0.17.0 - 0.18.x    |                               keptn-contrib/helm-service:0.18.0                                        |
+|  Keptn Version   | [Helm-service Docker Image](https://github.com/keptn-contrib/helm-service/pkgs/container/helm-service) |
+|:----------------:|:------------------------------------------------------------------------------------------------------:|
+| 0.17.0 and older |                          Please use https://github.com/keptn/keptn/releases                            |
+|      0.18.0      |                                   keptn-contrib/helm-service:0.18.1                                    |
+
 
 Newer Keptn versions might be compatible, but compatibility has not been verified at the time of the release.
 
@@ -22,15 +31,19 @@ Newer Keptn versions might be compatible, but compatibility has not been verifie
 
 The *helm-service* is part of the *Execution Plane for Continuous Delivery*.
 
-You can find installation instructions [here](https://keptn.sh/docs/0.15.x/operate/install/#install-keptn).
-
 To install it next to your Keptn installation, you can use the following command:
 
 ```console
-helm install helm-service https://github.com/keptn/keptn/releases/download/<latest>/helm-service-<latest>.tgz -n keptn
+HELM_SERVICE_VERSION=0.18.1 # https://github.com/keptn-contrib/helm-service/releases
+helm install helm-service https://github.com/keptn-contrib/helm-service/releases/download/$HELM_SERVICE_VERSION/helm-service-$HELM_SERVICE_VERSION.tgz -n keptn
 ```
 
-Replace `<latest>` with a Keptn version available from the [release list](https://github.com/keptn/keptn/tags).
+## Uninstall
+
+You can uninstall it directly using `helm`, e.g.:
+```console
+helm uninstall helm-service -n keptn
+```
 
 ## Development
 
@@ -74,3 +87,7 @@ For a b/g deployment with an (evaluation) result equals fail, the `helm-service`
 The `sh.keptn.event.action.triggered` event stats that a remediation action has been triggered.
 The `helm-service` provides a replica scaling remediation action.
 ![](./sequence_diagrams/action-triggered.png)
+
+# LICENSE
+
+See [LICENSE](LICENSE).


### PR DESCRIPTION
Added info to use job-executor instead of helm-service.

Depends on https://github.com/keptn-contrib/artifacthub/pull/162