### PR TITLE
fix: Use distributor 0.18.0 for Keptn 0.18.0 compatibility

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,7 +23,7 @@ distributor:
   projectFilter: ""                          # Project to which this helm service belongs; default=all; comma-separated list to filter for set of projects
   image:
     repository: "docker.io/keptn/distributor" # Container Image Name
-    tag: "0.17.0"                             # Container Tag
+    tag: "0.18.0"                             # Container Tag
     pullPolicy: IfNotPresent                  # Kubernetes Image Pull Policy
   config:
     queueGroup:


### PR DESCRIPTION
During testing I noticed that helm-service does not work with Keptn 0.18, and I got the following error message:
```
failed to load chart: Error when reading chart carts-db from project sockshop: Received unexpected response: 500 500 Internal Server Error
```
This was most likely caused by using an old version of keptn/distributor. Updating fixes it:
![image](https://user-images.githubusercontent.com/56065213/187175206-43ea37b0-4f3f-402e-afcf-a94a3c8e366e.png)
