### PR TITLE
fix: fixingTestAPIConnection: fixing the test-api-connection yaml whe…

### DIFF
--- a/chart/templates/tests/test-api-connection.yaml
+++ b/chart/templates/tests/test-api-connection.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "helm-service.fullname" . }}-test-api-connection"
-  labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
+  labels: {{- include "helm-service.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "helm-service.name" . }}
   annotations:
     "helm.sh/hook": test


### PR DESCRIPTION
### Description: 

When deploying the helm service with the latest version. And setting the remoteControlPlane.Enabled value = true
The helm-service  deployment fails.

### Error Message:

`Error: INSTALLATION FAILED: template: helm-service/templates/tests/test-api-connection.yaml:6:14: executing "helm-service/templates/tests/test-api-connection.yaml" at <include "keptn.common.labels.standard" .>: error calling include: template: no template "keptn.common.labels.standard" associated with template "gotpl"`

### Steps to re-produce the error

1. `$ HELM_SERVICE_VERSION=0.18.1`
2. `$ helm install helm-service https://github.com/keptn-contrib/helm-service/releases/download/$HELM_SERVICE_VERSION/helm-service-$HELM_SERVICE_VERSION.tgz -n keptn --create-namespace --set remoteControlPlane.enabled=true --set 	remoteControlPlane.api.hostname="<HOST_NAME>"   --set remoteControlPlane.api.token=<API_KEY>`


### Cause
I've noticed that the **_test-api-connection.yaml_**  is using  `{{- include "keptn.common.labels.standard" . | nindent 4 }}` 
and the template file containing the _"keptn.common.labels.standard"_ template is not present

### Fix

- Adding the common template 
- Replacing `{{- include "keptn.common.labels.standard" . | nindent 4 }}`  with `{{- include "helm-service.labels" . | nindent 4 }}`
